### PR TITLE
authorised access to footer links without needing to be logged in

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,6 +1,7 @@
 class PagesController < ApplicationController
+  skip_before_action :authenticate_user!, only: %i[about_us contact_us terms_of_services]
+  
   def create
     redirect_to root_path, notice: "Your message has been successfully sent ❤️"
   end
-
 end


### PR DESCRIPTION
added skip_before_action for the three footer pages in the pages controller so users now can access these when not logged in